### PR TITLE
Add option to specify which posts to export

### DIFF
--- a/process/simple_csv_xls_exporter_csv_xls.php
+++ b/process/simple_csv_xls_exporter_csv_xls.php
@@ -41,7 +41,15 @@ function simple_csv_xls_exporter_csv_xls(){
     //echo $user_id;
     //echo get_the_author_meta( 'display_name', $user_id );exit;
 
-    // Get the custom fields (for the custom post type) that are being exported
+	//Get only the specific posts by ID
+	$specific_posts = isset($_REQUEST['specific_posts']) ? $_REQUEST['specific_posts'] : get_option('ccsve_specified_posts');
+	if($specific_posts == '') {
+		$specific_posts = array();
+	} else {
+		$specific_posts = explode(",", $specific_posts);
+	}
+    
+	// Get the custom fields (for the custom post type) that are being exported
     $ccsve_generate_custom_fields = get_option('ccsve_custom_fields');
     $ccsve_generate_std_fields = get_option('ccsve_std_fields');
     $ccsve_generate_tax_terms = get_option('ccsve_tax_terms');
@@ -58,6 +66,7 @@ function simple_csv_xls_exporter_csv_xls(){
             'posts_per_page' => -1,
             'author' => $user_id,
             'order' => 'ASC',
+			'post_in' => $specific_posts,
             //'orderby' => 'name'
         ));
 
@@ -86,6 +95,7 @@ function simple_csv_xls_exporter_csv_xls(){
             'posts_per_page' => -1,
             'author' => $user_id,
             'order' => 'ASC',
+			'post_in' => $specific_posts,
             //'orderby' => 'name'
         ));
 
@@ -98,6 +108,7 @@ function simple_csv_xls_exporter_csv_xls(){
             'posts_per_page' => -1,
             'author' => $user_id,
             'order' => 'ASC',
+			'post__in' => $specific_posts,
             //'orderby' => 'name'
         ));
 
@@ -380,4 +391,3 @@ function simple_csv_xls_exporter_csv_xls(){
 
     }
 }
-?>

--- a/settings.php
+++ b/settings.php
@@ -13,6 +13,7 @@ if(!class_exists('SIMPLE_CSV_EXPORTER_SETTINGS')) {
             register_setting('wp_ccsve-group', 'ccsve_delimiter');
             register_setting('wp_ccsve-group', 'ccsve_admin_only');
             register_setting('wp_ccsve-group', 'ccsve_post_type');
+			register_setting('wp_ccsve-group', 'ccsve_specified_posts');
             register_setting('wp_ccsve-group', 'ccsve_post_status');
             register_setting('wp_ccsve-group', 'ccsve_std_fields');
             register_setting('wp_ccsve-group', 'ccsve_tax_terms');
@@ -51,6 +52,14 @@ if(!class_exists('SIMPLE_CSV_EXPORTER_SETTINGS')) {
                 'simple_csv_exporter_settings-section'
             );
 
+			add_settings_field(
+                'ccsve_specified_posts',
+                'Only Export Specified Post IDs',
+                array(&$this, 'settings_field_select_specified_posts'),
+                'simple_csv_exporter_settings',
+                'simple_csv_exporter_settings-section'
+            );
+
             add_settings_field(
                 'ccsve_post_status',
                 'Post Status to Export',
@@ -74,7 +83,7 @@ if(!class_exists('SIMPLE_CSV_EXPORTER_SETTINGS')) {
                 'simple_csv_exporter_settings',
                 'simple_csv_exporter_settings-section'
             );
-
+			
             add_settings_field(
                 'ccsve_tax_terms',
                 'Taxonomy Terms to Export',
@@ -99,7 +108,7 @@ if(!class_exists('SIMPLE_CSV_EXPORTER_SETTINGS')) {
             if($csv_delimiter == '') $csv_delimiter = '|';
             echo '<input type="text" id="csv_delimiter" name="ccsve_delimiter" value="'.$csv_delimiter.'" />';
         }
-
+		
         public function settings_field_select_admin() {
             // Get the value of this setting
             $admin_only = get_option('ccsve_admin_only');
@@ -143,7 +152,13 @@ if(!class_exists('SIMPLE_CSV_EXPORTER_SETTINGS')) {
                 echo ' <br />';
             }
         }
-
+		
+		public function settings_field_select_specified_posts() {
+            $specific_posts = get_option('ccsve_specified_posts');
+            if($specific_posts == '') $specific_posts = '';
+            echo '<input type="text" id="specific_posts" name="ccsve_specified_posts" value="'.$specific_posts.'" />';
+        }
+		
         public function settings_field_select_post_status() {
 			error_reporting(E_ERROR | E_PARSE);
             //global $items;

--- a/simple-csv-xls-exporter.php
+++ b/simple-csv-xls-exporter.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/plugins/simple-csv-xls-exporter/
 Description: Export posts to CSV or XLS, through a link from backend/frontend. Supports custom post types, WooCommerce products, custom taxonomies and fields.
 Author: Shambix
 Author URI: http://www.shambix.com
-Version: 1.4.6
+Version: 1.4.7
 */
 
 /*


### PR DESCRIPTION
This pull request adds an option to specify which posts are included in the export.  It adds a text field on the settings page where a user can put a comma separated list of post IDs.  It also adds the ability to use the specific_posts parameter in the URL.  